### PR TITLE
Added `register_all` macro

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
     Reflect,
     FromReflect,
 )]
-#[reflect_value(Serialize, Deserialize, PartialEq, Hash)]
+#[reflect_value(Deserialize, PartialEq, Hash)]
 pub enum HandleId {
     Id(Uuid, u64),
     AssetPathId(AssetPathId),

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -60,19 +60,19 @@ impl<'a> AssetPath<'a> {
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, Reflect,
 )]
-#[reflect_value(PartialEq, Hash, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Hash, Deserialize)]
 pub struct AssetPathId(SourcePathId, LabelId);
 
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, Reflect,
 )]
-#[reflect_value(PartialEq, Hash, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Hash, Deserialize)]
 pub struct SourcePathId(u64);
 
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, Reflect,
 )]
-#[reflect_value(PartialEq, Hash, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Hash, Deserialize)]
 pub struct LabelId(u64);
 
 impl<'a> From<&'a Path> for SourcePathId {

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -122,7 +122,7 @@ impl<C: Component + Reflect + FromWorld> FromType<C> for ReflectComponent {
     }
 }
 
-impl_reflect_value!(Entity(Hash, PartialEq, Serialize, Deserialize));
+impl_reflect_value!(Entity(Hash, PartialEq, Deserialize));
 impl_from_reflect_value!(Entity);
 
 #[derive(Clone)]

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -2,8 +2,8 @@ extern crate proc_macro;
 
 mod from_reflect;
 mod reflect_trait;
-mod type_uuid;
 mod registration;
+mod type_uuid;
 
 use bevy_macro_utils::BevyManifest;
 use proc_macro::TokenStream;
@@ -53,17 +53,17 @@ pub fn derive_reflect(input: TokenStream) -> TokenStream {
     let unit_struct_punctuated = Punctuated::new();
     let (fields, mut derive_type) = match &ast.data {
         Data::Struct(DataStruct {
-                         fields: Fields::Named(fields),
-                         ..
-                     }) => (&fields.named, DeriveType::Struct),
+            fields: Fields::Named(fields),
+            ..
+        }) => (&fields.named, DeriveType::Struct),
         Data::Struct(DataStruct {
-                         fields: Fields::Unnamed(fields),
-                         ..
-                     }) => (&fields.unnamed, DeriveType::TupleStruct),
+            fields: Fields::Unnamed(fields),
+            ..
+        }) => (&fields.unnamed, DeriveType::TupleStruct),
         Data::Struct(DataStruct {
-                         fields: Fields::Unit,
-                         ..
-                     }) => (&unit_struct_punctuated, DeriveType::UnitStruct),
+            fields: Fields::Unit,
+            ..
+        }) => (&unit_struct_punctuated, DeriveType::UnitStruct),
         _ => (&unit_struct_punctuated, DeriveType::Value),
     };
 
@@ -86,7 +86,7 @@ pub fn derive_reflect(input: TokenStream) -> TokenStream {
                             }
                             Ok(())
                         })
-                            .expect("Invalid 'property' attribute format.");
+                        .expect("Invalid 'property' attribute format.");
 
                         attribute_args
                     }),
@@ -99,9 +99,9 @@ pub fn derive_reflect(input: TokenStream) -> TokenStream {
         .filter(|(_field, attrs, _i)| {
             attrs.is_none()
                 || match attrs.as_ref().unwrap().ignore {
-                Some(ignore) => !ignore,
-                None => true,
-            }
+                    Some(ignore) => !ignore,
+                    None => true,
+                }
         })
         .map(|(f, _attr, i)| (*f, *i))
         .collect::<Vec<(&Field, usize)>>();
@@ -710,17 +710,17 @@ pub fn derive_from_reflect(input: TokenStream) -> TokenStream {
     let unit_struct_punctuated = Punctuated::new();
     let (fields, mut derive_type) = match &ast.data {
         Data::Struct(DataStruct {
-                         fields: Fields::Named(fields),
-                         ..
-                     }) => (&fields.named, DeriveType::Struct),
+            fields: Fields::Named(fields),
+            ..
+        }) => (&fields.named, DeriveType::Struct),
         Data::Struct(DataStruct {
-                         fields: Fields::Unnamed(fields),
-                         ..
-                     }) => (&fields.unnamed, DeriveType::TupleStruct),
+            fields: Fields::Unnamed(fields),
+            ..
+        }) => (&fields.unnamed, DeriveType::TupleStruct),
         Data::Struct(DataStruct {
-                         fields: Fields::Unit,
-                         ..
-                     }) => (&unit_struct_punctuated, DeriveType::UnitStruct),
+            fields: Fields::Unit,
+            ..
+        }) => (&unit_struct_punctuated, DeriveType::UnitStruct),
         _ => (&unit_struct_punctuated, DeriveType::Value),
     };
 
@@ -743,7 +743,7 @@ pub fn derive_from_reflect(input: TokenStream) -> TokenStream {
                             }
                             Ok(())
                         })
-                            .expect("Invalid 'property' attribute format.");
+                        .expect("Invalid 'property' attribute format.");
 
                         attribute_args
                     }),
@@ -756,9 +756,9 @@ pub fn derive_from_reflect(input: TokenStream) -> TokenStream {
         .filter(|(_field, attrs, _i)| {
             attrs.is_none()
                 || match attrs.as_ref().unwrap().ignore {
-                Some(ignore) => !ignore,
-                None => true,
-            }
+                    Some(ignore) => !ignore,
+                    None => true,
+                }
         })
         .map(|(f, _attr, i)| (*f, *i))
         .collect::<Vec<(&Field, usize)>>();
@@ -839,7 +839,7 @@ pub fn impl_from_reflect_value(input: TokenStream) -> TokenStream {
 ///     traits: [MyTrait],
 ///     types: [MyType, MyOtherType],
 /// }
-/// 
+///
 /// ```
 #[proc_macro]
 pub fn register_all(item: TokenStream) -> TokenStream {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -1,0 +1,111 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{bracketed, parse_macro_input, Token, Type};
+use syn::punctuated::{Iter, Punctuated};
+use bevy_macro_utils::BevyManifest;
+
+
+pub fn register_all_internal(item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as RegisterAllData);
+
+    let registration_params = input.types().map(|ty| {
+        let trait_type = input.traits();
+        quote! {
+            #ty, #(#trait_type),*
+        }
+    });
+
+    let bevy_reflect_path = BevyManifest::default().get_path("bevy_reflect");
+
+    TokenStream::from(quote! {
+        pub fn register_types(registry: &mut #bevy_reflect_path::TypeRegistry) {
+            #(#bevy_reflect_path::register_type!(registry, #registration_params));*
+        }
+    })
+}
+
+/// Maps to the following invocation:
+///
+/// ```
+/// use bevy_reflect_derive::register_all;
+///
+/// trait MyTrait {}
+/// struct MyType {}
+///
+/// register_all! {
+///     traits: [MyTrait],
+///     types: [MyType],
+/// }
+/// ```
+///
+/// > Note: The order of the `traits` and `types` fields does not matter. Additionally,
+/// > the commas (separating and trailing) may be omitted entirely.
+struct RegisterAllData {
+    trait_list: Punctuated<Type, Token![,]>,
+    type_list: Punctuated<Type, Token![,]>,
+}
+
+impl RegisterAllData {
+    /// Returns an iterator over the types to register.
+    fn types(&self) -> Iter<Type> {
+        self.type_list.iter()
+    }
+
+    /// Returns an iterator over the traits to register.
+    fn traits(&self) -> Iter<Type> {
+        self.trait_list.iter()
+    }
+
+    /// Parse a list of types.
+    ///
+    /// This is the portion _after_ the the respective keyword and consumes: `: [ Foo, Bar, Baz ]`
+    fn parse_list(input: &mut ParseStream) -> syn::Result<Punctuated<Type, Token![,]>> {
+        input.parse::<Token![:]>()?;
+        let list;
+        bracketed!(list in input);
+        list.parse_terminated(Type::parse)
+    }
+}
+
+impl Parse for RegisterAllData {
+    fn parse(mut input: ParseStream) -> syn::Result<Self> {
+        let trait_list;
+        let type_list;
+
+        let lookahead = input.lookahead1();
+        if lookahead.peek(kw::traits) {
+            // Parse `traits` then `types`
+            input.parse::<kw::traits>()?;
+            trait_list = Self::parse_list(&mut input)?;
+            // Optional separating comma
+            input.parse::<Option<Token![,]>>()?;
+            input.parse::<kw::types>()?;
+            type_list = Self::parse_list(&mut input)?;
+            // Optional trailing comma
+            input.parse::<Option<Token![,]>>()?;
+        } else if lookahead.peek(kw::types) {
+            // Parse `types` then `traits`
+            input.parse::<kw::types>()?;
+            type_list = Self::parse_list(&mut input)?;
+            // Optional separating comma
+            input.parse::<Option<Token![,]>>()?;
+            input.parse::<kw::traits>()?;
+            trait_list = Self::parse_list(&mut input)?;
+            // Optional trailing comma
+            input.parse::<Option<Token![,]>>()?;
+        } else {
+            return Err(syn::Error::new(input.span(), "expected either 'traits' or 'types' field"));
+        }
+
+        Ok(Self {
+            trait_list,
+            type_list,
+        })
+    }
+}
+
+mod kw {
+    syn::custom_keyword!(traits);
+    syn::custom_keyword!(types);
+}

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -1,10 +1,9 @@
+use bevy_macro_utils::BevyManifest;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
-use syn::{bracketed, parse_macro_input, Token, Type};
 use syn::punctuated::{Iter, Punctuated};
-use bevy_macro_utils::BevyManifest;
-
+use syn::{bracketed, parse_macro_input, Token, Type};
 
 pub fn register_all_internal(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as RegisterAllData);
@@ -95,7 +94,10 @@ impl Parse for RegisterAllData {
             // Optional trailing comma
             input.parse::<Option<Token![,]>>()?;
         } else {
-            return Err(syn::Error::new(input.span(), "expected either 'traits' or 'types' field"));
+            return Err(syn::Error::new(
+                input.span(),
+                "expected either 'traits' or 'types' field",
+            ));
         }
 
         Ok(Self {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -51,13 +51,13 @@ pub use erased_serde;
 #[cfg(test)]
 #[allow(clippy::blacklisted_name, clippy::approx_constant)]
 mod tests {
-    use std::any::TypeId;
     use ::serde::de::DeserializeSeed;
     use bevy_utils::HashMap;
     use ron::{
         ser::{to_string_pretty, PrettyConfig},
         Deserializer,
     };
+    use std::any::TypeId;
 
     use super::*;
     use crate as bevy_reflect;

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -447,18 +447,41 @@ mod tests {
         impl SomeTrait for Foo {}
         impl SomeTrait for Bar {}
 
+        struct SomeTypeData;
+        impl TypeData for SomeTypeData {
+            fn clone_type_data(&self) -> Box<dyn TypeData> {
+                Box::new(SomeTypeData)
+            }
+        }
+
+        // Register a set of types and traits
         register_all! {
             traits: [SomeTrait],
             types: [Foo, Bar, Baz]
         }
 
         let mut registry = TypeRegistry::default();
-        register_types(&mut registry);
 
+        // Pre-register `Foo`
+        registry.register::<Foo>();
+        let foo = registry.get_mut(TypeId::of::<Foo>()).unwrap();
+        foo.insert(SomeTypeData);
+
+        // Register all and make sure it doesn't overwrite any existing data
+        assert!(registry
+            .get_type_data::<SomeTypeData>(TypeId::of::<Foo>())
+            .is_some());
+        register_types(&mut registry);
+        assert!(registry
+            .get_type_data::<SomeTypeData>(TypeId::of::<Foo>())
+            .is_some());
+
+        // Test that Foo has the proper trait casts
         let ty = registry.get(TypeId::of::<Foo>()).unwrap();
         assert!(ty.trait_cast::<dyn SomeTrait>(&Foo).is_some());
         assert!(ty.trait_cast::<dyn NoneTrait>(&Foo).is_none());
 
+        // Test that Baz has no trait casts
         let ty = registry.get(TypeId::of::<Baz>()).unwrap();
         assert!(ty.trait_cast::<dyn SomeTrait>(&Baz).is_none());
         assert!(ty.trait_cast::<dyn NoneTrait>(&Baz).is_none());

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -219,18 +219,22 @@ macro_rules! maybe_trait_cast {
 }
 
 #[macro_export]
-macro_rules! register_type{
-    ($type_registry:ident, $this_type:ty, $($trait_type:path),* $(,)?) => {
-        {{
-        let mut type_registration = <$this_type as $crate::GetTypeRegistration>::get_type_registration();
+macro_rules! register_type {
+    ($type_registry:ident, $this_type:ty, $($trait_type:path),* $(,)?) => {{
+        let type_registration = match $type_registry.get_mut(::std::any::TypeId::of::<$this_type>()) {
+            Some(registration) => registration,
+            None => {
+                $type_registry.register::<$this_type>();
+                $type_registry.get_mut(::std::any::TypeId::of::<$this_type>()).unwrap()
+            }
+        };
+
         $(
             if let Some(cast_fn) = $crate::maybe_trait_cast!($this_type, $trait_type) {{
                 type_registration.register_trait_cast::<dyn $trait_type>(cast_fn);
             }}
         )*
-        $type_registry.add_registration(type_registration);
-    }}
-    };
+    }};
 }
 
 /// A record of data about a type.
@@ -533,7 +537,9 @@ mod test {
     }
 
     trait Test {}
+
     impl Test for HashMap<u32, u32> {}
+
     trait TestNot {}
 
     // the user should specify all traits in a top-level crate.

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -155,11 +155,13 @@ pub struct ErasedNonNull {
 }
 
 impl ErasedNonNull {
-    pub fn new<T: ?Sized>(val: &T, type_id: TypeId) -> Self {
+    /// Creates a new type-erased [`ErasedNonNull`] instance for the given value.
+    pub fn new<T: ?Sized + 'static>(val: &T) -> Self {
         let size = core::mem::size_of::<*const T>();
         assert!(size <= core::mem::size_of::<[NonNull<()>; 2]>());
         let val = val as *const T;
         let mut storage = MaybeUninit::uninit();
+        // SAFE: Size of reference pointer guaranteed to fit within storage
         unsafe {
             core::ptr::copy(
                 &val as *const *const T as *const u8,
@@ -169,11 +171,22 @@ impl ErasedNonNull {
         };
         Self {
             storage,
-            ty: type_id,
+            ty: TypeId::of::<T>(),
         }
     }
-    pub unsafe fn as_ref<'a, T: ?Sized + 'static>(self) -> &'a T {
-        assert!(self.ty == TypeId::of::<T>());
+
+    /// Converts this type-erased value into a typed one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the type `T` does not match the underlying type.
+    ///
+    /// # Safety
+    ///
+    /// Since the type `T` _must_ match the underlying type (or else panics), this method is
+    /// guaranteed to be safe.
+    pub unsafe fn into_ref<'a, T: ?Sized + 'static>(self) -> &'a T {
+        assert_eq!(self.ty, TypeId::of::<T>());
         let size = core::mem::size_of::<*const T>();
         let mut r: MaybeUninit<*const T> = MaybeUninit::uninit();
         core::ptr::copy(
@@ -190,14 +203,17 @@ macro_rules! maybe_trait_cast {
     ($this_type:ty, $trait_type:path) => {{
         {
             trait NotTrait {
-                const CAST_FN: Option<for<'a> fn(&'a $this_type) -> &'a dyn $trait_type> = None;
+                const CAST_FN: Option<
+                    for<'a> fn(&'a $this_type) -> &'a (dyn $trait_type + 'static),
+                > = None;
             }
             impl<T> NotTrait for T {}
             struct IsImplemented<T>(core::marker::PhantomData<T>);
 
             impl<T: $trait_type + 'static> IsImplemented<T> {
                 #[allow(dead_code)]
-                const CAST_FN: Option<for<'a> fn(&'a T) -> &'a dyn $trait_type> = Some(|a| a);
+                const CAST_FN: Option<for<'a> fn(&'a T) -> &'a (dyn $trait_type + 'static)> =
+                    Some(|a| a);
             }
             if IsImplemented::<$this_type>::CAST_FN.is_some() {
                 let f: fn(&dyn $crate::Reflect) -> $crate::ErasedNonNull =
@@ -205,10 +221,7 @@ macro_rules! maybe_trait_cast {
                         let cast_fn = IsImplemented::<$this_type>::CAST_FN.unwrap();
                         let static_val: &$this_type = val.downcast_ref::<$this_type>().unwrap();
                         let trait_val: &dyn $trait_type = (cast_fn)(static_val);
-                        $crate::ErasedNonNull::new(
-                            trait_val,
-                            core::any::TypeId::of::<dyn $trait_type>(),
-                        )
+                        $crate::ErasedNonNull::new(trait_val)
                     };
                 Some(f)
             } else {
@@ -283,7 +296,8 @@ impl TypeRegistration {
     pub fn trait_cast<'a, T: ?Sized + 'static>(&self, val: &'a dyn Reflect) -> Option<&'a T> {
         if let Some(cast) = self.trait_casts.get(&TypeId::of::<T>()) {
             let raw = cast(val);
-            Some(unsafe { raw.as_ref() })
+            // SAFE: Registered trait and type matches the call site
+            Some(unsafe { raw.into_ref() })
         } else {
             None
         }
@@ -464,8 +478,9 @@ impl<T: for<'a> Deserialize<'a> + Reflect> FromType<T> for ReflectDeserialize {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
+    use std::any::Any;
 
     #[test]
     fn test_get_short_name() {
@@ -572,5 +587,35 @@ mod test {
             .trait_cast::<dyn erased_serde::Serialize>(&3u32)
             .is_some());
         assert!(ty.trait_cast::<dyn Test>(&3u32).is_none());
+    }
+
+    #[test]
+    fn erased_non_null_should_work() {
+        // &str -> &str
+        let input = "Hello, World!";
+        let erased = ErasedNonNull::new(input);
+        let output = unsafe { erased.into_ref::<str>() };
+        assert_eq!(input, output);
+        assert_eq!(input.type_id(), output.type_id());
+
+        // &dyn Test -> &dyn Test
+        let input: &dyn Test = &HashMap::<u32, u32>::default();
+        let erased = ErasedNonNull::new(input);
+        let output = unsafe { erased.into_ref::<dyn Test>() };
+        assert_eq!(input.type_id(), output.type_id());
+
+        // &() -> &()
+        let input: () = ();
+        let erased = ErasedNonNull::new(&input);
+        let output = unsafe { erased.into_ref::<()>() };
+        assert_eq!(input.type_id(), output.type_id());
+    }
+
+    #[test]
+    #[should_panic]
+    fn erased_non_null_should_panic_for_wrong_type() {
+        let input = "Hello, World!";
+        let erased = ErasedNonNull::new(input);
+        let output = unsafe { erased.into_ref::<i32>() };
     }
 }

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -616,6 +616,6 @@ mod tests {
     fn erased_non_null_should_panic_for_wrong_type() {
         let input = "Hello, World!";
         let erased = ErasedNonNull::new(input);
-        let output = unsafe { erased.into_ref::<i32>() };
+        let _ = unsafe { erased.into_ref::<i32>() };
     }
 }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -106,7 +106,7 @@ impl RenderTarget {
 }
 
 #[derive(Debug, Clone, Copy, Reflect, Serialize, Deserialize)]
-#[reflect_value(Serialize, Deserialize)]
+#[reflect_value(Deserialize)]
 pub enum DepthCalculation {
     /// Pythagorean distance; works everywhere, more expensive to compute.
     Distance,

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -51,14 +51,14 @@ impl Default for PerspectiveProjection {
 
 // TODO: make this a component instead of a property
 #[derive(Debug, Clone, Reflect, Serialize, Deserialize)]
-#[reflect_value(Serialize, Deserialize)]
+#[reflect_value(Deserialize)]
 pub enum WindowOrigin {
     Center,
     BottomLeft,
 }
 
 #[derive(Debug, Clone, Reflect, Serialize, Deserialize)]
-#[reflect_value(Serialize, Deserialize)]
+#[reflect_value(Deserialize)]
 pub enum ScalingMode {
     /// Manually specify left/right/top/bottom values.
     /// Ignore window resizing; the image will stretch.

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Add, AddAssign, Mul, MulAssign};
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(PartialEq, Deserialize)]
 pub enum Color {
     /// sRGBA color
     Rgba {

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -87,7 +87,7 @@ impl Default for TextAlignment {
 
 /// Describes horizontal alignment preference for positioning & bounds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
-#[reflect_value(Serialize, Deserialize)]
+#[reflect_value(Deserialize)]
 pub enum HorizontalAlign {
     /// Leftmost character is immediately to the right of the render position.<br/>
     /// Bounds start from the render position and advance rightwards.
@@ -113,7 +113,7 @@ impl From<HorizontalAlign> for glyph_brush_layout::HorizontalAlign {
 /// Describes vertical alignment preference for positioning & bounds. Currently a placeholder
 /// for future functionality.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
-#[reflect_value(Serialize, Deserialize)]
+#[reflect_value(Deserialize)]
 pub enum VerticalAlign {
     /// Characters/bounds start underneath the render position and progress downwards.
     Top,

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -18,7 +18,7 @@ use smallvec::SmallVec;
 ///
 /// This is commonly queried with a `Changed<Interaction>` filter.
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect_value(Component, Serialize, Deserialize, PartialEq)]
+#[reflect_value(Component, Deserialize, PartialEq)]
 pub enum Interaction {
     /// The node has been clicked
     Clicked,
@@ -36,7 +36,7 @@ impl Default for Interaction {
 
 /// Describes whether the node should block interactions with lower nodes
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect_value(Component, Serialize, Deserialize, PartialEq)]
+#[reflect_value(Component, Deserialize, PartialEq)]
 pub enum FocusPolicy {
     /// Blocks interaction
     Block,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -19,7 +19,7 @@ pub struct Node {
 
 /// An enum that describes possible types of value in flexbox layout options
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum Val {
     /// No value defined
     Undefined,
@@ -144,7 +144,7 @@ impl Default for Style {
 
 /// How items are aligned according to the cross axis
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum AlignItems {
     /// Items are aligned at the start
     FlexStart,
@@ -166,7 +166,7 @@ impl Default for AlignItems {
 
 /// Works like [`AlignItems`] but applies only to a single item
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum AlignSelf {
     /// Use the value of [`AlignItems`]
     Auto,
@@ -192,7 +192,7 @@ impl Default for AlignSelf {
 ///
 /// It only applies if [`FlexWrap::Wrap`] is present and if there are multiple lines of items.
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum AlignContent {
     /// Each line moves towards the start of the cross axis
     FlexStart,
@@ -220,7 +220,7 @@ impl Default for AlignContent {
 ///
 /// For example English is written LTR (left-to-right) while Arabic is written RTL (right-to-left).
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum Direction {
     /// Inherit from parent node
     Inherit,
@@ -238,7 +238,7 @@ impl Default for Direction {
 
 /// Whether to use Flexbox layout
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum Display {
     /// Use flexbox
     Flex,
@@ -254,7 +254,7 @@ impl Default for Display {
 
 /// Defines how flexbox items are ordered within a flexbox
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum FlexDirection {
     /// Same way as text direction along the main axis
     Row,
@@ -274,7 +274,7 @@ impl Default for FlexDirection {
 
 /// Defines how items are aligned according to the main axis
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum JustifyContent {
     /// Pushed towards the start
     FlexStart,
@@ -298,7 +298,7 @@ impl Default for JustifyContent {
 
 /// Whether to show or hide overflowing items
 #[derive(Copy, Clone, PartialEq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum Overflow {
     /// Show overflowing items
     Visible,
@@ -314,7 +314,7 @@ impl Default for Overflow {
 
 /// The strategy used to position this node
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum PositionType {
     /// Relative to all other nodes with the [`PositionType::Relative`] value
     Relative,
@@ -332,7 +332,7 @@ impl Default for PositionType {
 
 /// Defines if flexbox items appear on a single line or on multiple lines
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum FlexWrap {
     /// Single line, will overflow if needed
     NoWrap,

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 /// Describes how to resize the Image node
 #[derive(Component, Debug, Clone, Reflect, Serialize, Deserialize)]
-#[reflect_value(Component, Serialize, Deserialize)]
+#[reflect_value(Component, Deserialize)]
 pub enum ImageMode {
     /// Keep the aspect ratio of the image
     KeepAspect,

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -34,7 +34,7 @@ pub struct C(usize);
 /// `Reflect::serialize()`. You can force these implementations to use the actual trait
 /// implementations (instead of their defaults) like this:
 #[derive(Reflect, Hash, Serialize, PartialEq)]
-#[reflect(Hash, Serialize, PartialEq)]
+#[reflect(Hash, PartialEq)]
 pub struct D {
     x: usize,
 }
@@ -45,7 +45,7 @@ pub struct D {
 /// traits on `reflect_value` types to ensure that these values behave as expected when nested
 /// underneath Reflect-ed structs.
 #[derive(Reflect, Copy, Clone, PartialEq, Serialize, Deserialize)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum E {
     X,
     Y,


### PR DESCRIPTION
## Changes

Adds the `register_all` macro.

This allows for mass type registration by generating a function that registers all the given types and traits. The function generated has the signature: `fn register_types(&mut TypeRegistry)`.

## Example

```rust
// registration.rs
use bevy_reflect_derive::register_all;

trait MyTrait {}
struct MyType;
struct MyOtherType;

impl MyTrait for MyType {}

// Not all types need to implement all traits
register_all! {
  traits: [ MyTrait ],
  types: [ MyType, MyOtherType ],
}

// plugin.rs
crate::registration::register_types(&mut type_registry);
```